### PR TITLE
docs: README - styled component example is missing a closing bracket after DocViewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,11 +214,11 @@ Each component / div already has a DOM id that can be used to style any part of 
 ```tsx
 import styled from "styled-components";
 //...
-<MyDocViewer documents={docs}/>
+<MyDocViewer documents={docs} />;
 //...
-const MyDocViewer = styled(DocViewer`
- border-radius: 10px;
-`
+const MyDocViewer = styled(DocViewer)`
+  border-radius: 10px;
+`;
 ```
 
 ### Config


### PR DESCRIPTION
Fixes #31