### PR TITLE
Fix pptx Filetypes Not Being Recognized

### DIFF
--- a/src/plugins/msdoc/index.tsx
+++ b/src/plugins/msdoc/index.tsx
@@ -45,6 +45,7 @@ MSDocRenderer.fileTypes = [
   ...MSDocFTMaps.xls,
   ...MSDocFTMaps.xlsx,
   ...MSDocFTMaps.ppt,
+  ...MSDocFTMaps.pptx,
 ];
 MSDocRenderer.weight = 0;
 MSDocRenderer.fileLoader = ({ fileLoaderComplete }) => fileLoaderComplete();


### PR DESCRIPTION
**Issue:** XML based ppt files (pptx) are able to be rendered by are not recognized by `MSDocRenderer`.

**Fix:** Super minor fix. Add the pptx file format to the `MSDocRenderer` `filetypes`.