### PR TITLE
Added http header properties for applying to file loaders

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,6 +37,7 @@ export interface IDocument {
   uri: string;
   fileType?: string;
   fileData?: string | ArrayBuffer;
+  headers?: Record<string, string>;
 }
 
 export interface DocRendererProps {
@@ -46,4 +47,5 @@ export interface DocRenderer extends FC<DocRendererProps> {
   fileTypes: string[];
   weight: number;
   fileLoader?: FileLoaderFunction | null | undefined;
+  headers?: Record<string, string>;
 }

--- a/src/utils/fileLoaders.ts
+++ b/src/utils/fileLoaders.ts
@@ -2,7 +2,9 @@ export interface FileLoaderFuncProps {
   documentURI: string;
   signal: AbortSignal;
   fileLoaderComplete: FileLoaderComplete;
+  headers?: Record<string, string>;
 }
+
 export type FileLoaderComplete = (fileReader?: FileReader) => void;
 export type FileLoaderFunction = (props: FileLoaderFuncProps) => void;
 
@@ -15,10 +17,11 @@ type BaseFileLoaderFunction = (props: BaseFileLoaderFuncOptions) => void;
 const _fileLoader: BaseFileLoaderFunction = ({
   documentURI,
   signal,
+  headers,
   fileLoaderComplete,
   readerTypeFunction,
 }) => {
-  return fetch(documentURI, { signal })
+  return fetch(documentURI, { signal, headers })
     .then(async (res) => {
       const blob = await res.blob();
 

--- a/src/utils/useDocumentLoader.ts
+++ b/src/utils/useDocumentLoader.ts
@@ -33,7 +33,7 @@ export const useDocumentLoader = (): {
       const controller = new AbortController();
       const { signal } = controller;
 
-      fetch(documentURI, { method: "HEAD", signal }).then((response) => {
+      fetch(documentURI, { method: "HEAD", signal, headers: currentDocument.headers }).then((response) => {
         const contentTypeRaw = response.headers.get("content-type");
         const contentTypes = contentTypeRaw?.split(";") || [];
         const contentType = contentTypes.length ? contentTypes[0] : undefined;
@@ -80,9 +80,9 @@ export const useDocumentLoader = (): {
     if (CurrentRenderer === null) {
       dispatch(setDocumentLoading(false));
     } else if (CurrentRenderer.fileLoader !== undefined) {
-      CurrentRenderer.fileLoader?.({ documentURI, signal, fileLoaderComplete });
+      CurrentRenderer.fileLoader?.({ documentURI, signal, fileLoaderComplete, headers: currentDocument.headers });
     } else {
-      defaultFileLoader({ documentURI, signal, fileLoaderComplete });
+      defaultFileLoader({ documentURI, signal, fileLoaderComplete, headers: currentDocument.headers });
     }
 
     return () => {


### PR DESCRIPTION
Pretty straight forward pass through for Http headers so that they can be used in the fetch requests.

closes: #81 