### PR TITLE
feat: add prefetchMethod option

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,23 @@ MyCustomPNGRenderer.fileLoader = ({
 <br />
 <br />
 
+### Custom pre-fetch HTTP Verb
+
+Some services (such as AWS) provide URLs that works only for one pre-configured verb.
+By default, `react-doc-viewer` fetches document metadata through a `HEAD` request in order to guess its `Content-Type`.
+If you need to have a specific verb for the pre-fetching, use the `prefetchMethod` option on the DocViewer:
+
+```tsx
+import DocViewer, { DocViewerRenderers } from "react-doc-viewer";
+
+<DocViewer
+  prefetchMethod="GET"
+/>;
+```
+
+<br />
+<br />
+
 ### Themed
 
 You can provide a theme object with one or all of the available properties.
@@ -368,6 +385,7 @@ const myHeader: IHeaderOverride = (state, previousDocument, nextDocument) => {
 | config?          | [`IConfig`](#iconfig)           |
 | theme?           | [`ITheme`](#itheme)             |
 | pluginRenderers? | [`DocRenderer[]`](#docrenderer) |
+| prefetchMethod?  | `string`                        |
 
 ---
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,6 +23,7 @@ export interface DocViewerProps {
   config?: IConfig;
   theme?: ITheme;
   pluginRenderers?: DocRenderer[];
+  prefetchMethod?: string;
 }
 
 const DocViewer: FC<DocViewerProps> = (props) => {

--- a/src/state/index.tsx
+++ b/src/state/index.tsx
@@ -20,7 +20,7 @@ const DocViewerContext = createContext<{
 }>({ state: initialState, dispatch: () => null });
 
 const AppProvider: FC<DocViewerProps> = (props) => {
-  const { children, documents, config, pluginRenderers } = props;
+  const { children, documents, config, pluginRenderers, prefetchMethod } = props;
 
   const [state, dispatch] = useReducer<MainStateReducer>(mainStateReducer, {
     ...initialState,
@@ -28,6 +28,7 @@ const AppProvider: FC<DocViewerProps> = (props) => {
     currentDocument: documents && documents.length ? documents[0] : undefined,
     config,
     pluginRenderers,
+    prefetchMethod,
   });
 
   // On inital load, and whenever they change,

--- a/src/state/reducer.ts
+++ b/src/state/reducer.ts
@@ -23,6 +23,7 @@ export type IMainState = {
   rendererRect?: DOMRect;
   config?: IConfig;
   pluginRenderers?: DocRenderer[];
+  prefetchMethod?: string;
 };
 
 export const initialState: IMainState = {

--- a/src/utils/useDocumentLoader.ts
+++ b/src/utils/useDocumentLoader.ts
@@ -19,7 +19,7 @@ export const useDocumentLoader = (): {
   CurrentRenderer: DocRenderer | null | undefined;
 } => {
   const { state, dispatch } = useContext(DocViewerContext);
-  const { currentFileNo, currentDocument } = state;
+  const { currentFileNo, currentDocument, prefetchMethod } = state;
 
   const { CurrentRenderer } = useRendererSelector();
 
@@ -33,7 +33,7 @@ export const useDocumentLoader = (): {
       const controller = new AbortController();
       const { signal } = controller;
 
-      fetch(documentURI, { method: "HEAD", signal }).then((response) => {
+      fetch(documentURI, { method: prefetchMethod || "HEAD", signal }).then((response) => {
         const contentTypeRaw = response.headers.get("content-type");
         const contentTypes = contentTypeRaw?.split(";") || [];
         const contentType = contentTypes.length ? contentTypes[0] : undefined;


### PR DESCRIPTION
Some services (such as AWS) provide URLs that works only for one pre-configured verb.
By default, `react-doc-viewer` fetches document metadata through a `HEAD` request in order to guess its `Content-Type`.
If you need to have a specific verb for the pre-fetching, use the `prefetchMethod` option on the DocViewer:

```tsx
import DocViewer from "react-doc-viewer";

<DocViewer
  prefetchMethod="GET"
/>;
```