### PR TITLE
[Security] Update react-pdf and pdfjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
  "main": "build/index.js",
  "types": "build/index.d.ts",
  "dependencies": {
-  "pdfjs-dist": "4.2.67",
-  "react-pdf": "8.0.2",
+  "pdfjs-dist": "4.3.136",
+  "react-pdf": "9.0.0",
   "styled-components": "^5.3.11",
   "wl-msg-reader": "^0.2.0"
  },


### PR DESCRIPTION
This version updates PDF.js to 4.3.136, fixing GHSA-wgrm-67xf-hhpq.

React-PDF v8.0.2 already included a mitigation of the issue and thus were not affected by this vulnerability, but caused automatic security alerts due to the outdated PDF.js version.

Breaking changes to confirm are ok with your project:
- PDF.js worker extension has been changed from .js to .mjs.
- Dropped support for older browsers and Node.js versions. In particular, you may need Promise.withResolvers polyfill when running Node.js versions older than 22.0.0.