### PR TITLE
TS build fix

### DIFF
--- a/tsconfig-npm.json
+++ b/tsconfig-npm.json
@@ -15,7 +15,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     // "noEmit": true,
-    "jsx": "react"
+    "jsx": "react",
+    "types": []
   },
   "include": ["src"],
   "exclude": [


### PR DESCRIPTION
fix(build): resolve TypeScript build error by adjusting tsconfig type resolution

- Added "types": [] to tsconfig-npm.json to prevent TypeScript from including implicit global types (e.g. minimatch)
- Keeps the build clean for library packaging
- No functional or runtime impact